### PR TITLE
修复无法选择视觉模型和pdf下载转换后的markdown文件出现损坏的问题

### DIFF
--- a/components/text-split/FileUploader.js
+++ b/components/text-split/FileUploader.js
@@ -9,8 +9,6 @@ import UploadArea from './components/UploadArea';
 import FileList from './components/FileList';
 import DeleteConfirmDialog from './components/DeleteConfirmDialog';
 import PdfProcessingDialog from './components/PdfProcessingDialog';
-import { useAtomValue } from 'jotai/index';
-import { modelConfigListAtom, selectedModelInfoAtom } from '@/lib/store';
 
 /**
  * File uploader component
@@ -46,8 +44,6 @@ export default function FileUploader({
   const [fileToDelete, setFileToDelete] = useState({});
   const [taskSettings, setTaskSettings] = useState(null);
   const [visionModels, setVisionModels] = useState([]);
-  const model = useAtomValue(modelConfigListAtom);
-  const selectModel = useAtomValue(selectedModelInfoAtom);
   // 设置PDF文件的处理方式
   const handleRadioChange = event => {
     // 传递这个值的原因是setSelectedViosnModel是异步的,PdfProcessingDialog检测到模型变更设置新的值
@@ -101,6 +97,9 @@ export default function FileUploader({
       const taskData = await taskResponse.json();
 
       setTaskSettings(taskData);
+
+      //使用Jotai会出现数据获取的延迟，导致这里模型获取不到，改用localStorage获取模型信息
+      const model =  JSON.parse(localStorage.getItem('modelConfigList'));
 
       //过滤出视觉模型
       const visionItems = model.filter(item => item.type === 'vision' && item.apiKey);

--- a/components/text-split/components/FileList.js
+++ b/components/text-split/components/FileList.js
@@ -58,12 +58,18 @@ export default function FileList({
     setPageLoading(true);
     const text = await getFileContent(fileId);
 
+     // Modify the filename if it ends with .pdf
+     let downloadName = fileName || 'download.txt';
+     if (downloadName.toLowerCase().endsWith('.pdf')) {
+         downloadName = downloadName.slice(0, -4) + '.md';
+     }
+
     const blob = new Blob([text.content], { type: 'text/plain' });
     const url = URL.createObjectURL(blob);
 
     const a = document.createElement('a');
     a.href = url;
-    a.download = fileName || 'download.txt';
+    a.download = downloadName;
 
     document.body.appendChild(a);
     a.click();


### PR DESCRIPTION
fix: 1.unable to retrieve model information correctly, resulting in the inability to select a visual model for PDF conversion.

2. the PDF file was not correctly downloaded or converted into the Markdown file.